### PR TITLE
Pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ Ensure `~/go/bin` is in your `PATH`.
 crow [--watch path] [--ext extensions] command
 ```
 
+Crow can also take in a list of file names from `stdin`.
+
+```bash
+fd .go | crow command
+ls | crow command
+find . | crow command
+echo main.go | crow command
+```
+
 ### Use cases
 
 Use `crow` to run tests once you save `main.go`.

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func App(pwd string) *cli.App {
 				Name:    "ext",
 				Aliases: []string{"e"},
 				Value:   cli.NewStringSlice(""),
-				Usage:   "File extensions to watch",
+				Usage:   "Files or extensions to watch",
 			},
 		},
 		Action: start.Crow,

--- a/start/start.go
+++ b/start/start.go
@@ -1,6 +1,7 @@
 package start
 
 import (
+	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -60,7 +61,23 @@ func Crow(cli *cli.Context) error {
 		done <- true
 	}()
 
-	err := filepath.Walk(dir, Traverse(cli.StringSlice("ext"), w.Add))
+	var stdin []byte
+	var err error
+	var exts []string
+
+	stat, _ := os.Stdin.Stat()
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
+		stdin, err = ioutil.ReadAll(os.Stdin)
+		exts = strings.Fields(string(stdin))
+	} else {
+		exts = cli.StringSlice("ext")
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = filepath.Walk(dir, Traverse(exts, w.Add))
 	if err != nil {
 		return err
 	}

--- a/start/start_test.go
+++ b/start/start_test.go
@@ -17,6 +17,12 @@ func TestTraverse(t *testing.T) {
 		{[]string{"go"}, []string{"start.go", "start_test.go"}},
 		{[]string{"md"}, []string{""}},
 		{[]string{"text"}, []string{"foo.text"}},
+		{[]string{"foo.text"}, []string{"foo.text"}},
+		{[]string{"crow/start/foo.text"}, []string{"foo.text"}},
+		{[]string{"start.go"}, []string{"start.go"}},
+		{[]string{"start_test.go"}, []string{"start_test.go"}},
+		{[]string{"start_test.go", "start.go"}, []string{"start.go", "start_test.go"}},
+		{[]string{"foo.text", "start.go", "foo.text"}, []string{"foo.text", "start.go", "start_test.go"}},
 	}
 
 	_, err := os.Create("foo.text")


### PR DESCRIPTION
Fixes #2 

### Changes Introduced
- Ability to input filenames from stdin to watch

This uses a little bit of a hack since extensions just matches the suffix instead of using `.go` or actual extensions we can just add the full path.

We should deprecate the `-w` and `-e` fields and replace it with `-f/--files`, if the `-f` flag isn't provided then we should look in the current directory and look at all extensions.